### PR TITLE
Prevent inopportune collision errors with unconnected faces in Convex shapes 

### DIFF
--- a/src/math/Vec3.js
+++ b/src/math/Vec3.js
@@ -13,24 +13,10 @@ import { Mat3 } from './Mat3'
  *     console.log('x=' + v.x); // x=1
  */
 export class Vec3 {
-  constructor(x, y, z) {
-    /**
-     * @property x
-     * @type {Number}
-     */
-    this.x = x || 0.0
-
-    /**
-     * @property y
-     * @type {Number}
-     */
-    this.y = y || 0.0
-
-    /**
-     * @property z
-     * @type {Number}
-     */
-    this.z = z || 0.0
+  constructor(x = 0.0, y = 0.0, z = 0.0) {
+    this.x = x
+    this.y = y
+    this.z = z
   }
 
   /**
@@ -40,14 +26,13 @@ export class Vec3 {
    * @param {Vec3} target Optional. Target to save in.
    * @return {Vec3}
    */
-  cross(v, target) {
+  cross(v, target = new Vec3()) {
     const vx = v.x
     const vy = v.y
     const vz = v.z
     const x = this.x
     const y = this.y
     const z = this.z
-    target = target || new Vec3()
 
     target.x = y * vz - z * vy
     target.y = z * vx - x * vz
@@ -305,13 +290,19 @@ export class Vec3 {
     return target
   }
 
+  /**
+   * Compute two artificial tangents to the vector
+   * @method tangents
+   * @param {Vec3} t1 Vector object to save the first tangent in
+   * @param {Vec3} t2 Vector object to save the second tangent in
+   */
   tangents(t1, t2) {
     const norm = this.norm()
     if (norm > 0.0) {
-      const n = Vec3_tangents_n
+      const n = new Vec3()
       const inorm = 1 / norm
       n.set(this.x * inorm, this.y * inorm, this.z * inorm)
-      const randVec = Vec3_tangents_randVec
+      const randVec = new Vec3()
       if (Math.abs(n.x) < 0.9) {
         randVec.set(1, 0, 0)
         n.cross(randVec, t1)
@@ -381,10 +372,7 @@ export class Vec3 {
    * @param {Number} precision
    * @return bool
    */
-  almostEquals({ x, y, z }, precision) {
-    if (precision === undefined) {
-      precision = 1e-6
-    }
+  almostEquals({ x, y, z }, precision = 1e-6) {
     if (Math.abs(this.x - x) > precision || Math.abs(this.y - y) > precision || Math.abs(this.z - z) > precision) {
       return false
     }
@@ -396,10 +384,7 @@ export class Vec3 {
    * @method almostZero
    * @param {Number} precision
    */
-  almostZero(precision) {
-    if (precision === undefined) {
-      precision = 1e-6
-    }
+  almostZero(precision = 1e-6) {
     if (Math.abs(this.x) > precision || Math.abs(this.y) > precision || Math.abs(this.z) > precision) {
       return false
     }
@@ -415,7 +400,7 @@ export class Vec3 {
    */
   isAntiparallelTo(v, precision) {
     this.negate(antip_neg)
-    return antip_neg.almostEquals(v, precision)
+    return new Vec3().almostEquals(v, precision)
   }
 
   /**
@@ -474,14 +459,3 @@ Vec3.prototype.lengthSquared = Vec3.prototype.norm2
  * @return {Vec3}
  */
 Vec3.prototype.scale = Vec3.prototype.mult
-
-/**
- * Compute two artificial tangents to the vector
- * @method tangents
- * @param {Vec3} t1 Vector object to save the first tangent in
- * @param {Vec3} t2 Vector object to save the second tangent in
- */
-const Vec3_tangents_n = new Vec3()
-const Vec3_tangents_randVec = new Vec3()
-
-const antip_neg = new Vec3()

--- a/src/shapes/Box.js
+++ b/src/shapes/Box.js
@@ -65,7 +65,7 @@ export class Box extends Shape {
 
     const axes = [new V(0, 0, 1), new V(0, 1, 0), new V(1, 0, 0)]
 
-    const h = new ConvexPolyhedron(vertices, indices)
+    const h = new ConvexPolyhedron(vertices, indices, axes)
     this.convexPolyhedronRepresentation = h
     h.material = this.material
   }

--- a/src/shapes/Sphere.js
+++ b/src/shapes/Sphere.js
@@ -36,7 +36,7 @@ export class Sphere extends Shape {
   }
 
   volume() {
-    return (4.0 * Math.PI * this.radius) / 3.0
+    return 4.0 * Math.PI * Math.pow(this.radius, 3) / 3.0
   }
 
   updateBoundingSphereRadius() {


### PR DESCRIPTION
Additionally adds an extra parameter to bypass bounding sphere radius and faceNormals calculations, if supplied with a THREE.Geometry that contains such information.

These changes work in tandem with changes in use-cannon, to better support ConvexPolyHedron.

--
While looking into this I cleaned up some formatting, passed axes to the convexPoly constructor within Box, and corrected the sphere volume formula.