### PR TITLE
fix some quirks in World.step when attempting to account for variable framerate

### DIFF
--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -395,9 +395,6 @@ export class World extends EventTarget {
       // Fixed, simple stepping
 
       this.internalStep(dt)
-
-      // Increment time
-      this.time += dt
     } else {
       this.accumulator += timeSinceLastCalled
       let substeps = 0
@@ -418,7 +415,6 @@ export class World extends EventTarget {
         b.previousQuaternion.slerp(b.quaternion, t, b.interpolatedQuaternion)
         b.previousQuaternion.normalize()
       }
-      this.time += timeSinceLastCalled
     }
   }
 

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -388,6 +388,7 @@ export class World extends EventTarget {
    *     world.step(1/60);
    *
    * @see http://bulletphysics.org/mediawiki-1.5.8/index.php/Stepping_The_World
+   * @see https://gafferongames.com/post/fix_your_timestep/
    */
   step(dt: number, timeSinceLastCalled = 0, maxSubSteps = 10): void {
     if (timeSinceLastCalled === 0) {

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -390,8 +390,8 @@ export class World extends EventTarget {
    * @see http://bulletphysics.org/mediawiki-1.5.8/index.php/Stepping_The_World
    * @see https://gafferongames.com/post/fix_your_timestep/
    */
-  step(dt: number, timeSinceLastCalled = 0, maxSubSteps = 10): void {
-    if (timeSinceLastCalled === 0) {
+  step(dt: number, timeSinceLastCalled?: number, maxSubSteps: number = 10): void {
+    if (timeSinceLastCalled === undefined) {
       // Fixed, simple stepping
 
       this.internalStep(dt)

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -408,7 +408,10 @@ export class World extends EventTarget {
         substeps++
       }
 
-      const t = (this.accumulator % dt) / dt
+      // prevent the accumulator to build up delay to catch up. The logic being: if the step did not catch up at this frame, it is unlikely to catch up in the next one. Even if it does, it will result in a speed up simulation which is arguably worse that staying behind the real time.
+      this.accumulator = Math.max(this.accumulator, dt)
+
+      const t = this.accumulator / dt
       for (let j = 0; j !== this.bodies.length; j++) {
         const b = this.bodies[j]
         b.previousPosition.lerp(b.position, t, b.interpolatedPosition)


### PR DESCRIPTION
Limit accumulator growth as proposed in https://github.com/schteppe/cannon.js/pull/392

Also fix what seems to be a mistake where this.time is increase in `world.step` and at the same time in `world.internalStep` . I am unsure about the implications, this value was used to handle sleep status in bodies.

This fix unfortunately does not address https://github.com/react-spring/cannon-es/issues/16 as I was still able to reproduce the midair freezing cubes. I notice it seems to happens less frequently though. The investigation continues :)