### PR TITLE
check if window is set (when running in worker)

### DIFF
--- a/dist/cannon-es.cjs.js
+++ b/dist/cannon-es.cjs.js
@@ -9127,7 +9127,7 @@ class Trimesh extends Shape {
         const n = this.vertices.length / 3,
             verts = this.vertices;
         const minx,miny,minz,maxx,maxy,maxz;
-          const v = tempWorldVertex;
+         const v = tempWorldVertex;
         for(let i=0; i<n; i++){
             this.getVertex(i, v);
             quat.vmult(v, v);
@@ -9137,12 +9137,12 @@ class Trimesh extends Shape {
             } else if(v.x > maxx || maxx===undefined){
                 maxx = v.x;
             }
-              if (v.y < miny || miny===undefined){
+             if (v.y < miny || miny===undefined){
                 miny = v.y;
             } else if(v.y > maxy || maxy===undefined){
                 maxy = v.y;
             }
-              if (v.z < minz || minz===undefined){
+             if (v.z < minz || minz===undefined){
                 minz = v.z;
             } else if(v.z > maxz || maxz===undefined){
                 maxz = v.z;
@@ -12198,7 +12198,7 @@ class World extends EventTarget {
 const tmpAABB1 = new AABB();
 const tmpRay$1 = new Ray(); // performance.now() fallback on Date.now()
 
-const performance = require('perf_hooks').performance || {};
+const performance = typeof window != 'undefined' && require('perf_hooks').performance || {};
 
 if (!performance.now) {
   let nowOffset = Date.now();

--- a/dist/cannon-es.js
+++ b/dist/cannon-es.js
@@ -9123,7 +9123,7 @@ class Trimesh extends Shape {
         const n = this.vertices.length / 3,
             verts = this.vertices;
         const minx,miny,minz,maxx,maxy,maxz;
-          const v = tempWorldVertex;
+         const v = tempWorldVertex;
         for(let i=0; i<n; i++){
             this.getVertex(i, v);
             quat.vmult(v, v);
@@ -9133,12 +9133,12 @@ class Trimesh extends Shape {
             } else if(v.x > maxx || maxx===undefined){
                 maxx = v.x;
             }
-              if (v.y < miny || miny===undefined){
+             if (v.y < miny || miny===undefined){
                 miny = v.y;
             } else if(v.y > maxy || maxy===undefined){
                 maxy = v.y;
             }
-              if (v.z < minz || minz===undefined){
+             if (v.z < minz || minz===undefined){
                 minz = v.z;
             } else if(v.z > maxz || maxz===undefined){
                 maxz = v.z;
@@ -12194,7 +12194,7 @@ class World extends EventTarget {
 const tmpAABB1 = new AABB();
 const tmpRay$1 = new Ray(); // performance.now() fallback on Date.now()
 
-const performance = window.performance || {};
+const performance = typeof window != 'undefined' && window.performance || {};
 
 if (!performance.now) {
   let nowOffset = Date.now();

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -800,7 +800,7 @@ const tmpArray1 = []
 const tmpRay = new Ray()
 
 // performance.now() fallback on Date.now()
-const performance = (window.performance || {}) as Performance
+const performance = ((typeof window != 'undefined' && window.performance) || {}) as Performance
 
 if (!performance.now) {
   let nowOffset = Date.now()


### PR DESCRIPTION
Hey,

Not sure if this is the right fix, but I'm currently using cannon-es in a project I'm working on and when running the physics in a worker it crashed because of the reference to the window property.

I'm not sure If the build is ok, I'm not used to working with yarn...

Ps: is there a watch option that can be used while developing the package ?