### PR TITLE
Fix issue with window in worker

### DIFF
--- a/dist/cannon-es.cjs.js
+++ b/dist/cannon-es.cjs.js
@@ -9127,7 +9127,7 @@ class Trimesh extends Shape {
         const n = this.vertices.length / 3,
             verts = this.vertices;
         const minx,miny,minz,maxx,maxy,maxz;
-          const v = tempWorldVertex;
+         const v = tempWorldVertex;
         for(let i=0; i<n; i++){
             this.getVertex(i, v);
             quat.vmult(v, v);
@@ -9137,12 +9137,12 @@ class Trimesh extends Shape {
             } else if(v.x > maxx || maxx===undefined){
                 maxx = v.x;
             }
-              if (v.y < miny || miny===undefined){
+             if (v.y < miny || miny===undefined){
                 miny = v.y;
             } else if(v.y > maxy || maxy===undefined){
                 maxy = v.y;
             }
-              if (v.z < minz || minz===undefined){
+             if (v.z < minz || minz===undefined){
                 minz = v.z;
             } else if(v.z > maxz || maxz===undefined){
                 maxz = v.z;

--- a/dist/cannon-es.js
+++ b/dist/cannon-es.js
@@ -9123,7 +9123,7 @@ class Trimesh extends Shape {
         const n = this.vertices.length / 3,
             verts = this.vertices;
         const minx,miny,minz,maxx,maxy,maxz;
-          const v = tempWorldVertex;
+         const v = tempWorldVertex;
         for(let i=0; i<n; i++){
             this.getVertex(i, v);
             quat.vmult(v, v);
@@ -9133,12 +9133,12 @@ class Trimesh extends Shape {
             } else if(v.x > maxx || maxx===undefined){
                 maxx = v.x;
             }
-              if (v.y < miny || miny===undefined){
+             if (v.y < miny || miny===undefined){
                 miny = v.y;
             } else if(v.y > maxy || maxy===undefined){
                 maxy = v.y;
             }
-              if (v.z < minz || minz===undefined){
+             if (v.z < minz || minz===undefined){
                 minz = v.z;
             } else if(v.z > maxz || maxz===undefined){
                 maxz = v.z;
@@ -12194,7 +12194,7 @@ class World extends EventTarget {
 const tmpAABB1 = new AABB();
 const tmpRay$1 = new Ray(); // performance.now() fallback on Date.now()
 
-const performance = window.performance || {};
+const performance = globalThis.performance || {};
 
 if (!performance.now) {
   let nowOffset = Date.now();

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,7 +40,7 @@ export default [
       sizeSnapshot(),
       replace({
         // Use node built-in performance.now in commonjs environments
-        'window.performance': `require('perf_hooks').performance`,
+        'globalThis.performance': `require('perf_hooks').performance`,
       }),
     ],
   },

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -800,7 +800,7 @@ const tmpArray1 = []
 const tmpRay = new Ray()
 
 // performance.now() fallback on Date.now()
-const performance = (window.performance || {}) as Performance
+const performance = (globalThis.performance || {}) as Performance
 
 if (!performance.now) {
   let nowOffset = Date.now()


### PR DESCRIPTION
Using window in a worker throws an error, let's use [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) instead.

Its browser support seems aligned with our browser support specified [here](https://github.com/react-spring/cannon-es/blob/fc0f1c481d09db667f170acafb8651d03bd37bb8/rollup.config.js#L20).

- `globalThis` browser support: https://caniuse.com/#feat=mdn-javascript_builtins_globalthis

- our supported browsers: https://browsersl.ist/?q=%3E1%25%2C+not+dead%2C+not+ie+11%2C+not+op_mini+all

Instead, if there is the need to support older browsers, we can easily transpile `globalThis` with babel.